### PR TITLE
add rubocop (lint only), coveralls, memoize some parsing ...

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+service_name: travis-ci

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Gemfile.lock
 tmp
 .yardoc/*
 doc/*
+coverage/*

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,10 @@
+inherit_from: .rubocop_todo.yml
+
+require: rubocop-rspec
+
+Metrics/LineLength:
+  Max: 120
+
+# shut hound up re: quote styles
+Style/StringLiterals:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 group :development do
-  gem 'pry-debugger', '0.2.2', platform: :ruby_19
+  gem 'pry-byebug'
 end
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,8 @@ end
 
 group :development, :test do
   gem 'yard'
+  gem 'rubocop'
+  gem 'rubocop-rspec'
 end
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,8 @@
 source 'https://rubygems.org'
 
-group :development do
-  gem 'pry-byebug'
-end
-
 group :development, :test do
-  gem 'yard'
-  gem 'rubocop'
-  gem 'rubocop-rspec'
+  gem 'pry-byebug'
+  gem 'coveralls', require: false
 end
 
 gemspec

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [<img src="https://travis-ci.org/sul-dlss/discovery-indexer.svg?branch=master" alt="Build Status" />](https://travis-ci.org/sul-dlss/discovery-indexer)
-[<img src="https://coveralls.io/repos/sul-dlss/discovery-indexer/badge.png" alt="Coverage Status" />](https://coveralls.io/r/sul-dlss/discovery-indexer)
+[![Coverage Status](https://coveralls.io/repos/github/sul-dlss/discovery-indexer/badge.svg?branch=master)](https://coveralls.io/github/sul-dlss/discovery-indexer?branch=master)
 [<img src="https://gemnasium.com/sul-dlss/discovery-indexer.svg" alt="Dependency Status" />](https://gemnasium.com/sul-dlss/discovery-indexer)
 [<img src="https://badge.fury.io/rb/discovery-indexer.svg" alt="Gem Version" />](http://badge.fury.io/rb/discovery-indexer)
 

--- a/Rakefile
+++ b/Rakefile
@@ -34,7 +34,7 @@ begin
   YARD::Rake::YardocTask.new(:doc) do |yt|
     yt.files = Dir.glob(File.join(project_root, 'lib', '**', '*.rb')) +
       [File.join(project_root, 'README.rdoc')]
-    yt.options = ['--output-dir', doc_dest_dir, '--readme', 'README.rdoc', '--title', 'Discovery Indexer Documentation']
+    yt.options = ['--output-dir', doc_dest_dir, '--readme', 'README.md', '--title', 'Discovery Indexer Gem']
   end
 rescue LoadError
   desc 'Generate YARD Documentation'

--- a/Rakefile
+++ b/Rakefile
@@ -18,12 +18,17 @@ end
 task default: :ci
 
 desc 'run continuous integration suite (tests, coverage, docs)'
-task ci: [:rspec, :doc]
+task ci: [:rspec, :rubocop]
 
 task spec: :rspec
 
 RSpec::Core::RakeTask.new(:rspec) do |spec|
   spec.rspec_opts = ['-c', '-f progress', '--tty', '-r ./spec/spec_helper.rb']
+end
+
+require 'rubocop/rake_task'
+RuboCop::RakeTask.new(:rubocop) do |task|
+  task.options = ['-l'] # run lint cops only
 end
 
 # Use yard to build docs

--- a/discovery-indexer.gemspec
+++ b/discovery-indexer.gemspec
@@ -24,4 +24,8 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'webmock'
   gem.add_development_dependency 'equivalent-xml'
   gem.add_development_dependency 'vcr'
+  gem.add_development_dependency 'yard'
+  gem.add_development_dependency 'rubocop'
+  gem.add_development_dependency 'rubocop-rspec'
+
 end

--- a/lib/discovery-indexer/collection.rb
+++ b/lib/discovery-indexer/collection.rb
@@ -22,14 +22,11 @@ module DiscoveryIndexer
 
     # Returns the collection name from cache, otherwise will fetch it from PURL.
     #
-    # @param collection_druid [String]  is the druid for a collection e.g., ab123cd4567
-    # @return [Array<String>] the collection data or [] if there is no name and catkey or the object
-    #   is not a collection
+    # @return [Hash] the collection data or [] if there is no name and catkey or the object is not a collection
     def collection_info
       from_purl || {}
     end
 
-    # @param [String] collection_druid is the druid for a collection e.g., ab123cd4567
     # @return [String] return the collection label from purl if available, nil otherwise
     def from_purl
       return unless purl_model

--- a/lib/discovery-indexer/general_mapper.rb
+++ b/lib/discovery-indexer/general_mapper.rb
@@ -5,10 +5,6 @@ module DiscoveryIndexer
 
     # Initializes an instance from IndexMapper
     # @param [String] druid e.g. ab123cd4567
-    # @param [Stanford::Mods::Record] modsxml represents the MODS xml for the druid
-    # @param [DiscoveryIndexer::Reader::PurlxmlModel] purlxml represents the purlxml model
-    # @param [Hash] collection_data represents a hash of collection_druid and catkey
-    # collection_data = {'aa00bb0001'=>{:name=>'Test Collection Name',:ckey=>'000001'},'nt028fd5773'=>{:name=>'Revs Institute Archive',:ckey=>'000002'}}
     def initialize(druid)
       @druid = druid
     end
@@ -24,19 +20,24 @@ module DiscoveryIndexer
 
     # It converts collection_druids list to a hash with names. If the druid doesn't
     # have a collection name, it will be excluded from the hash
-    # @return [Hash] a hash for collection druid and its name
-    #   !{"ab123cd4567"=>"Collection 1", "ef123gh4567"=>"Collection 2"}
+    # @return [Hash] a hash with key of coll druid, and value as a hash of name and ckey
+    # e.g. {'aa00bb0001'=>{:name=>'Test Coll Name',:ckey=>'000001'},'nt028fd5773'=>{:name=>'Revs Institute Archive',:ckey=>'000002'}}
     def collection_data
       @collection_data ||= collection_druids.map do |cdruid|
         DiscoveryIndexer::Collection.new(cdruid)
       end
     end
+
     def collection_druids
       purlxml.collection_druids
     end
+
+    # @return [Stanford::Mods::Record] the MODS xml for the druid
     def modsxml
       @modsxml ||= DiscoveryIndexer::InputXml::Modsxml.new(druid).load
     end
+
+    # @return [DiscoveryIndexer::Reader::PurlxmlModel] the purlxml model
     def purlxml
       @purlxml ||= DiscoveryIndexer::InputXml::Purlxml.new(druid).load
     end

--- a/lib/discovery-indexer/reader/purlxml.rb
+++ b/lib/discovery-indexer/reader/purlxml.rb
@@ -19,7 +19,7 @@ module DiscoveryIndexer
       # @return [PurlxmlModel] represents the purlxml
       def load
         @purlxml_ng_doc = PurlxmlReader.read(@druid) if @purlxml_ng_doc.nil?
-        purlxml_parser = PurlxmlParserStrict.new(@druid, @purlxml_ng_doc).parse
+        PurlxmlParserStrict.new(@druid, @purlxml_ng_doc).parse
       end
     end
   end

--- a/lib/discovery-indexer/reader/purlxml_parser_strict.rb
+++ b/lib/discovery-indexer/reader/purlxml_parser_strict.rb
@@ -39,6 +39,8 @@ module DiscoveryIndexer
         purlxml_model
       end
 
+      private
+
       # extracts the identityMetadata for this fedora object, from the purl xml
       # @return [Nokogiri::XML::Document] the identityMetadata for the fedora object
       # @raise [DiscoveryIndexer::Errors::MissingIdentityMetadata] if there is no identity_metadata

--- a/lib/discovery-indexer/reader/purlxml_parser_strict.rb
+++ b/lib/discovery-indexer/reader/purlxml_parser_strict.rb
@@ -43,17 +43,17 @@ module DiscoveryIndexer
       # @return [Nokogiri::XML::Document] the identityMetadata for the fedora object
       # @raise [DiscoveryIndexer::Errors::MissingIdentityMetadata] if there is no identity_metadata
       def parse_identity_metadata
-        ng_doc = Nokogiri::XML(@purlxml_ng_doc.root.xpath('/publicObject/identityMetadata').to_xml)
-        fail DiscoveryIndexer::Errors::MissingIdentityMetadata.new(@purlxml_ng_doc.inspect) if !ng_doc || ng_doc.children.empty?
-        ng_doc
+        @idmd_ng_doc ||= Nokogiri::XML(@purlxml_ng_doc.root.xpath('/publicObject/identityMetadata').to_xml)
+        fail DiscoveryIndexer::Errors::MissingIdentityMetadata.new(@purlxml_ng_doc.inspect) if !@idmd_ng_doc || @idmd_ng_doc.children.empty?
+        @idmd_ng_doc
       rescue
         raise DiscoveryIndexer::Errors::MissingIdentityMetadata.new(@purlxml_ng_doc.inspect)
       end
 
       def parse_rights_metadata
-        ng_doc = Nokogiri::XML(@purlxml_ng_doc.root.xpath('/publicObject/rightsMetadata').to_xml)
-        fail DiscoveryIndexer::Errors::MissingRightsMetadata.new(@purlxml_ng_doc.inspect) if !ng_doc || ng_doc.children.empty?
-        ng_doc
+        @rmd_ng_doc ||= Nokogiri::XML(@purlxml_ng_doc.root.xpath('/publicObject/rightsMetadata').to_xml)
+        fail DiscoveryIndexer::Errors::MissingRightsMetadata.new(@purlxml_ng_doc.inspect) if !@rmd_ng_doc || @rmd_ng_doc.children.empty?
+        @rmd_ng_doc
       rescue
         raise DiscoveryIndexer::Errors::MissingRightsMetadata.new(@purlxml_ng_doc.inspect)
       end
@@ -62,9 +62,9 @@ module DiscoveryIndexer
       # @return [Nokogiri::XML::Document] the dc for the fedora object
       # @raise [DiscoveryIndexer::Errors::MissingDC] if there is no dc element
       def parse_dc
-        ng_doc = Nokogiri::XML(@purlxml_ng_doc.root.xpath('/publicObject/dc:dc', 'dc' => OAI_DC_NAMESPACE).to_xml(encoding: 'utf-8'))
-        fail DiscoveryIndexer::Errors::MissingDC.new(@purlxml_ng_doc.inspect) if !ng_doc || ng_doc.children.empty?
-        ng_doc
+        @dc_ng_doc ||= Nokogiri::XML(@purlxml_ng_doc.root.xpath('/publicObject/dc:dc', 'dc' => OAI_DC_NAMESPACE).to_xml(encoding: 'utf-8'))
+        fail DiscoveryIndexer::Errors::MissingDC.new(@purlxml_ng_doc.inspect) if !@dc_ng_doc || @dc_ng_doc.children.empty?
+        @dc_ng_doc
       rescue
         raise DiscoveryIndexer::Errors::MissingDC.new(@purlxml_ng_doc.inspect)
       end
@@ -73,9 +73,9 @@ module DiscoveryIndexer
       # @return [Nokogiri::XML::Document] the rdf for the fedora object
       # @raise [DiscoveryIndexer::Errors::MissingRDF] if there is no rdf element
       def parse_rdf
-        ng_doc = Nokogiri::XML(@purlxml_ng_doc.root.xpath('/publicObject/rdf:RDF', 'rdf' => RDF_NAMESPACE).to_xml)
-        fail DiscoveryIndexer::Errors::MissingRDF.new(@purlxml_ng_doc.inspect) if !ng_doc || ng_doc.children.empty?
-        ng_doc
+        @rdf_ng_doc ||= Nokogiri::XML(@purlxml_ng_doc.root.xpath('/publicObject/rdf:RDF', 'rdf' => RDF_NAMESPACE).to_xml)
+        fail DiscoveryIndexer::Errors::MissingRDF.new(@purlxml_ng_doc.inspect) if !@rdf_ng_doc || @rdf_ng_doc.children.empty?
+        @rdf_ng_doc
       rescue
         raise DiscoveryIndexer::Errors::MissingRDF.new(@purlxml_ng_doc.inspect)
       end
@@ -101,9 +101,9 @@ module DiscoveryIndexer
       # @return [Nokogiri::XML::Document] the contentMetadata for the fedora object
       # @raise [DiscoveryIndexer::Errors::MissingContentMetadata] if there is no contentMetadata
       def parse_content_metadata
-        ng_doc = Nokogiri::XML(@purlxml_ng_doc.root.xpath('/publicObject/contentMetadata').to_xml)
-        ng_doc = nil if !ng_doc || ng_doc.children.empty?
-        ng_doc
+        @cntmd_ng_doc ||= Nokogiri::XML(@purlxml_ng_doc.root.xpath('/publicObject/contentMetadata').to_xml)
+        @cntmd_ng_doc = nil if !@cntmd_ng_doc || @cntmd_ng_doc.children.empty?
+        @cntmd_ng_doc
       end
 
       # @return true if the identityMetadata has <objectType>collection</objectType>, false otherwise

--- a/spec/discovery-indexer/reader/modsxml_spec.rb
+++ b/spec/discovery-indexer/reader/modsxml_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe DiscoveryIndexer::InputXml::Purlxml do
   describe '.load' do
-    it 'should load mods xml from the purl to the stanford mods model' do
+    it 'loads mods xml from purl page to the stanford mods model' do
       VCR.use_cassette('available_mods_xml') do
         druid = 'tn629pk3948'
         modsxml = DiscoveryIndexer::InputXml::Modsxml.new(druid)
@@ -11,11 +11,11 @@ describe DiscoveryIndexer::InputXml::Purlxml do
       end
     end
 
-    it "shouldn't re-read public xml from the purl if it is already available" do
+    it "doesn't re-read public xml from the purl if it is already available" do
       VCR.use_cassette('available_mods_xml') do
         druid = 'tn629pk3948'
         modsxml = DiscoveryIndexer::InputXml::Modsxml.new(druid)
-        modsxml_model = modsxml.load
+        modsxml.load
 
         modsxml.instance_variable_set(:@druid, 'aa111aa1111')
         modsxml_model = modsxml.load

--- a/spec/discovery-indexer/reader/purlxml_parser_strict_spec.rb
+++ b/spec/discovery-indexer/reader/purlxml_parser_strict_spec.rb
@@ -49,7 +49,7 @@ describe DiscoveryIndexer::InputXml::PurlxmlParserStrict do
 
   describe '#parse_identity_metadata' do
     it 'should returnt the identity metadata stream for the valid public xml' do
-      im = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', @available_purl_xml_ng_doc).parse_identity_metadata
+      im = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', @available_purl_xml_ng_doc).send(:parse_identity_metadata)
       expect(im).to be_kind_of(Nokogiri::XML::Document)
       expect(im.root.name).to eql('identityMetadata')
       expect(im.root.xpath('objectId').text).to eql('druid:tn629pk3948')
@@ -58,13 +58,13 @@ describe DiscoveryIndexer::InputXml::PurlxmlParserStrict do
 
     it "should raise an error when the public xml doesn't have identity metadata" do
       public_xml_no_identity = "<publicObject id='druid:aa111aa1111'>#{@content_metadata}#{@rights_metadata}</publicObject>"
-      expect { DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', public_xml_no_identity).parse_identity_metadata }.to raise_error(DiscoveryIndexer::Errors::MissingIdentityMetadata)
+      expect { DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', public_xml_no_identity).send(:parse_identity_metadata) }.to raise_error(DiscoveryIndexer::Errors::MissingIdentityMetadata)
     end
   end
 
   describe '#parse_rights_metadata' do
     it 'should returnt the rights metadata stream for the valid public xml' do
-      im = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', @available_purl_xml_ng_doc).parse_rights_metadata
+      im = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', @available_purl_xml_ng_doc).send(:parse_rights_metadata)
       expect(im).to be_kind_of(Nokogiri::XML::Document)
       expect(im.root.name).to eql('rightsMetadata')
       expect(im).to be_equivalent_to(Nokogiri::XML(@rights_metadata))
@@ -72,27 +72,27 @@ describe DiscoveryIndexer::InputXml::PurlxmlParserStrict do
 
     it "should raise an error when the public xml doesn't have rights metadata" do
       public_xml_no_rights = "<publicObject id='druid:aa111aa1111'>#{@content_metadata}#{@identity_metadata}</publicObject>"
-      expect { DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', public_xml_no_rights).parse_rights_metadata }.to raise_error(DiscoveryIndexer::Errors::MissingRightsMetadata)
+      expect { DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', public_xml_no_rights).send(:parse_rights_metadata) }.to raise_error(DiscoveryIndexer::Errors::MissingRightsMetadata)
     end
   end
 
   describe '#parse_dc' do
-    it 'should returnt the dc metadata stream for the valid public xml' do
-      im = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', @available_purl_xml_ng_doc).parse_dc
+    it 'returns the Nokogiri XML Document from dc metadata in purl public xml' do
+      im = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', @available_purl_xml_ng_doc).send(:parse_dc)
       expect(im).to be_kind_of(Nokogiri::XML::Document)
       expect(im.root.name).to eql('dc')
       expect(im).to be_equivalent_to(Nokogiri::XML(@dc))
     end
 
-    it 'should raise an error for the metadata without dc' do
+    it 'raises an error for the metadata without dc' do
       public_xml_no_dc = "<publicObject id='druid:aa111aa1111'>#{@rights_metadata}#{@identity_metadata}#{@content_metadata}</publicObject>"
-      expect { DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', public_xml_no_dc).parse_dc }.to raise_error(DiscoveryIndexer::Errors::MissingDC)
+      expect { DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', public_xml_no_dc).send(:parse_dc) }.to raise_error(DiscoveryIndexer::Errors::MissingDC)
     end
   end
 
   describe '#parse_rdf' do
     it 'should return the rdf for the valid public xml' do
-      im = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', @available_purl_xml_ng_doc).parse_rdf
+      im = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', @available_purl_xml_ng_doc).send(:parse_rdf)
       expect(im).to be_kind_of(Nokogiri::XML::Document)
       expect(im.root.name).to eql('RDF')
       expect(im).to be_equivalent_to(Nokogiri::XML(@rdf))
@@ -100,44 +100,44 @@ describe DiscoveryIndexer::InputXml::PurlxmlParserStrict do
 
     it 'should raise an error for the metadata without dc' do
       public_xml_no_dc = "<publicObject id='druid:aa111aa1111'>#{@rights_metadata}#{@identity_metadata}#{@content_metadata}</publicObject>"
-      expect { DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', public_xml_no_dc).parse_rdf }.to raise_error(DiscoveryIndexer::Errors::MissingRDF)
+      expect { DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', public_xml_no_dc).send(:parse_rdf) }.to raise_error(DiscoveryIndexer::Errors::MissingRDF)
     end
   end
 
   describe '#parse_release_tags_hash' do
     it 'parses the release tags from ReleaseData in public XML' do
-      release_tags_hash = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', @available_purl_xml_ng_doc).parse_release_tags_hash
+      release_tags_hash = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', @available_purl_xml_ng_doc).send(:parse_release_tags_hash)
       expect(release_tags_hash).to eq('revs_stage' => true, 'sw_prod' => false, 'sw_preview' => false)
     end
     it 'returns empty release tags from pulic XML in the absence of ReleaseData element' do
       reduced_purl_xml_ng = @available_purl_xml_ng_doc.clone
       reduced_purl_xml_ng.search('//ReleaseData').remove
-      release_tags_hash = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', reduced_purl_xml_ng).parse_release_tags_hash
+      release_tags_hash = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', reduced_purl_xml_ng).send(:parse_release_tags_hash)
       expect(release_tags_hash).to eq({})
     end
     it 'returns empty release tags from nil pulic XML' do
-      release_tags_hash = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', nil).parse_release_tags_hash
+      release_tags_hash = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', nil).send(:parse_release_tags_hash)
       expect(release_tags_hash).to eq({})
     end
   end
 
   describe '#parse_copyright' do
     it 'should parse the copyright statement correctly' do
-      copyright = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', @available_purl_xml_ng_doc).parse_copyright
+      copyright = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', @available_purl_xml_ng_doc).send(:parse_copyright)
       expect(copyright).to eq('Test copyright statement. All rights reserved unless otherwise indicated.')
     end
   end
 
   describe '#parse_use_and_reproduction' do
     it 'should parse the use and reproduction statement correctly' do
-      use_and_reproduction = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', @available_purl_xml_ng_doc).parse_use_and_reproduction
+      use_and_reproduction = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', @available_purl_xml_ng_doc).send(:parse_use_and_reproduction)
       expect(use_and_reproduction).to eq('Digital recordings from this collection may be accessed freely. These files may not be reproduced or used for any purpose without permission. For permission requests, please contact Stanford University Department of Special Collections  University Archives (speccollref@stanford.edu).')
     end
   end
 
   describe '#parse_content_metadata' do
     it 'should return the content metadata stream for the valid public xml' do
-      im = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', @available_purl_xml_ng_doc).parse_content_metadata
+      im = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', @available_purl_xml_ng_doc).send(:parse_content_metadata)
       expect(im).to be_kind_of(Nokogiri::XML::Document)
       expect(im.root.name).to eql('contentMetadata')
       expect(im).to be_equivalent_to(Nokogiri::XML(@content_metadata))
@@ -145,7 +145,7 @@ describe DiscoveryIndexer::InputXml::PurlxmlParserStrict do
 
     it "should return nil when the public xml doesn't have content metadata" do
       public_xml_no_content = "<publicObject id='druid:aa111aa1111'>#{@rights_metadata}#{@identity_metadata}</publicObject>"
-      cm = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', Nokogiri::XML(public_xml_no_content)).parse_content_metadata
+      cm = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', Nokogiri::XML(public_xml_no_content)).send(:parse_content_metadata)
       expect(cm).to be_nil
     end
   end
@@ -154,21 +154,21 @@ describe DiscoveryIndexer::InputXml::PurlxmlParserStrict do
     it 'should return nil when no content metadata is present' do
       public_xml_no_content = "<publicObject id='druid:aa111aa1111'>#{@rights_metadata}#{@identity_metadata}</publicObject>"
       pm = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', Nokogiri::XML(public_xml_no_content))
-      expect(pm.parse_image_ids).to be_nil
-      expect(pm.parse_file_ids).to be_nil
+      expect(pm.send(:parse_image_ids)).to be_nil
+      expect(pm.send(:parse_file_ids)).to be_nil
     end
 
     it 'should return nil when content metadata is present but no image or page ids are present' do
       public_xml_no_content = "<publicObject id='druid:aa111aa1111'>#{@rights_metadata}#{@identity_metadata}#{@blank_content_metadata}</publicObject>"
       pm = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', Nokogiri::XML(public_xml_no_content))
-      expect(pm.parse_image_ids).to be_empty
-      expect(pm.parse_file_ids).to be_nil
+      expect(pm.send(:parse_image_ids)).to be_empty
+      expect(pm.send(:parse_file_ids)).to be_nil
     end
 
     it 'should return image and page ids when present' do
       pm = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', @available_purl_xml_ng_doc)
-      expect(pm.parse_image_ids).to eq(['tn629pk3948_img_1.jp2', 'tn629pk3948_img_2.jp2', 'tn629pk3948_img_3.jp2', 'tn629pk3948_pg_1.jp2'])
-      expect(pm.parse_file_ids).to eq(["tn629pk3948_sl.mp4", "tn629pk3948_img_1.jp2", "tn629pk3948_img_2.jp2", "tn629pk3948_img_3.jp2", "tn629pk3948_pg_1.pdf", "tn629pk3948_pg_1.jp2", "tn629pk3948_pg_1.pdf"])
+      expect(pm.send(:parse_image_ids)).to eq(['tn629pk3948_img_1.jp2', 'tn629pk3948_img_2.jp2', 'tn629pk3948_img_3.jp2', 'tn629pk3948_pg_1.jp2'])
+      expect(pm.send(:parse_file_ids)).to eq(["tn629pk3948_sl.mp4", "tn629pk3948_img_1.jp2", "tn629pk3948_img_2.jp2", "tn629pk3948_img_3.jp2", "tn629pk3948_pg_1.pdf", "tn629pk3948_pg_1.jp2", "tn629pk3948_pg_1.pdf"])
     end
   end
 
@@ -186,13 +186,13 @@ describe DiscoveryIndexer::InputXml::PurlxmlParserStrict do
 
   describe '#parse_dor_content_type' do
     it 'should return valid dor content type for valid druid' do
-      content_type = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', @available_purl_xml_ng_doc).parse_dor_content_type
+      content_type = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', @available_purl_xml_ng_doc).send(:parse_dor_content_type)
       expect(content_type).to eq('media')
     end
 
     it 'should return nil dor content type if there is no content metadata' do
       public_xml_no_content = "<publicObject id='druid:aa111aa1111'>#{@rights_metadata}#{@identity_metadata}</publicObject>"
-      content_type = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', Nokogiri::XML(public_xml_no_content)).parse_dor_content_type
+      content_type = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', Nokogiri::XML(public_xml_no_content)).send(:parse_dor_content_type)
       expect(content_type).to be_nil
     end
   end
@@ -200,14 +200,14 @@ describe DiscoveryIndexer::InputXml::PurlxmlParserStrict do
   describe '#parse_dor_display_type' do
     it 'should return valid dor displayTypeype for valid druid' do
       public_xml_display_type = "<publicObject id='druid:aa111aa1111'>#{@rights_metadata}#{@identity_metadata}#{@content_metadata}</publicObject>"
-      display_type = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', Nokogiri::XML(public_xml_display_type)).parse_dor_display_type
+      display_type = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', Nokogiri::XML(public_xml_display_type)).send(:parse_dor_display_type)
       expect(display_type).to eq('image')
     end
 
     it 'should return nil dor displayType if there is no displayType in the identity metadata' do
       im_no_display_type = '  <identityMetadata>    <sourceId source="sul">V0401_b1_1.01</sourceId>    <objectId>druid:tn629pk3948</objectId>    <objectCreator>DOR</objectCreator>    <objectLabel>Lecture 1</objectLabel>    <objectType>item</objectType>    <adminPolicy>druid:ww057vk7675</adminPolicy>    <otherId name="label"/>    <otherId name="uuid">08d544da-d459-11e2-8afb-0050569b3c3c</otherId>    <tag>Project:V0401 mccarthyism:vhs</tag>    <tag> Process:Content Type:Media</tag>    <tag> JIRA:DIGREQ-592</tag>    <tag> SMPL:video:ua</tag>    <tag> Registered By:gwillard</tag>    <tag>Remediated By : 4.6.6.2</tag>  </identityMetadata>'
       public_xml_no_display_type = "<publicObject id='druid:aa111aa1111'>#{@rights_metadata}#{im_no_display_type}#{@content_metadata}</publicObject>"
-      display_type = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', Nokogiri::XML(public_xml_no_display_type)).parse_dor_display_type
+      display_type = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', Nokogiri::XML(public_xml_no_display_type)).send(:parse_dor_display_type)
       expect(display_type).to be_empty
     end
   end

--- a/spec/discovery-indexer/reader/purlxml_parser_strict_spec.rb
+++ b/spec/discovery-indexer/reader/purlxml_parser_strict_spec.rb
@@ -13,7 +13,7 @@ describe DiscoveryIndexer::InputXml::PurlxmlParserStrict do
     @rdf = '<rdf:RDF xmlns:fedora="info:fedora/fedora-system:def/relations-external#" xmlns:fedora-model="info:fedora/fedora-system:def/model#" xmlns:hydra="http://projecthydra.org/ns/relations#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">    <rdf:Description rdf:about="info:fedora/druid:tn629pk3948">      <fedora:isMemberOf rdf:resource="info:fedora/druid:yk804rq1656"/>      <fedora:isMemberOfCollection rdf:resource="info:fedora/druid:yk804rq1656"/>    </rdf:Description>  </rdf:RDF>'
   end
 
-  describe '.parse' do
+  describe '#parse' do
     it 'should call all methods and fill the require fields in the model' do
       parser = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('aa111aa1111', nil)
       allow(parser).to receive(:parse_content_metadata) { 'contentMetadata' }
@@ -47,7 +47,7 @@ describe DiscoveryIndexer::InputXml::PurlxmlParserStrict do
     end
   end
 
-  describe '.parse_identity_metadata' do
+  describe '#parse_identity_metadata' do
     it 'should returnt the identity metadata stream for the valid public xml' do
       im = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', @available_purl_xml_ng_doc).parse_identity_metadata
       expect(im).to be_kind_of(Nokogiri::XML::Document)
@@ -62,7 +62,7 @@ describe DiscoveryIndexer::InputXml::PurlxmlParserStrict do
     end
   end
 
-  describe '.parse_rights_metadata' do
+  describe '#parse_rights_metadata' do
     it 'should returnt the rights metadata stream for the valid public xml' do
       im = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', @available_purl_xml_ng_doc).parse_rights_metadata
       expect(im).to be_kind_of(Nokogiri::XML::Document)
@@ -76,7 +76,7 @@ describe DiscoveryIndexer::InputXml::PurlxmlParserStrict do
     end
   end
 
-  describe '.parse_dc' do
+  describe '#parse_dc' do
     it 'should returnt the dc metadata stream for the valid public xml' do
       im = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', @available_purl_xml_ng_doc).parse_dc
       expect(im).to be_kind_of(Nokogiri::XML::Document)
@@ -90,7 +90,7 @@ describe DiscoveryIndexer::InputXml::PurlxmlParserStrict do
     end
   end
 
-  describe '.parse_rdf' do
+  describe '#parse_rdf' do
     it 'should return the rdf for the valid public xml' do
       im = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', @available_purl_xml_ng_doc).parse_rdf
       expect(im).to be_kind_of(Nokogiri::XML::Document)
@@ -104,7 +104,7 @@ describe DiscoveryIndexer::InputXml::PurlxmlParserStrict do
     end
   end
 
-  describe '.parse_release_tags_hash' do
+  describe '#parse_release_tags_hash' do
     it 'parses the release tags from ReleaseData in public XML' do
       release_tags_hash = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', @available_purl_xml_ng_doc).parse_release_tags_hash
       expect(release_tags_hash).to eq('revs_stage' => true, 'sw_prod' => false, 'sw_preview' => false)
@@ -121,21 +121,21 @@ describe DiscoveryIndexer::InputXml::PurlxmlParserStrict do
     end
   end
 
-  describe '.parse_copyright' do
+  describe '#parse_copyright' do
     it 'should parse the copyright statement correctly' do
       copyright = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', @available_purl_xml_ng_doc).parse_copyright
       expect(copyright).to eq('Test copyright statement. All rights reserved unless otherwise indicated.')
     end
   end
 
-  describe '.parse_use_and_reproduction' do
+  describe '#parse_use_and_reproduction' do
     it 'should parse the use and reproduction statement correctly' do
       use_and_reproduction = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', @available_purl_xml_ng_doc).parse_use_and_reproduction
       expect(use_and_reproduction).to eq('Digital recordings from this collection may be accessed freely. These files may not be reproduced or used for any purpose without permission. For permission requests, please contact Stanford University Department of Special Collections  University Archives (speccollref@stanford.edu).')
     end
   end
 
-  describe '.parse_content_metadata' do
+  describe '#parse_content_metadata' do
     it 'should return the content metadata stream for the valid public xml' do
       im = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', @available_purl_xml_ng_doc).parse_content_metadata
       expect(im).to be_kind_of(Nokogiri::XML::Document)
@@ -172,19 +172,19 @@ describe DiscoveryIndexer::InputXml::PurlxmlParserStrict do
     end
   end
 
-  describe '.parse_catkey' do
+  describe '#parse_catkey' do
     pending
   end
 
-  describe '.parse_barcode' do
+  describe '#parse_barcode' do
     pending
   end
 
-  describe '.parse_label' do
+  describe '#parse_label' do
     pending
   end
 
-  describe '.parse_dor_content_type' do
+  describe '#parse_dor_content_type' do
     it 'should return valid dor content type for valid druid' do
       content_type = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', @available_purl_xml_ng_doc).parse_dor_content_type
       expect(content_type).to eq('media')
@@ -197,7 +197,7 @@ describe DiscoveryIndexer::InputXml::PurlxmlParserStrict do
     end
   end
 
-  describe '.parse_dor_display_type' do
+  describe '#parse_dor_display_type' do
     it 'should return valid dor displayTypeype for valid druid' do
       public_xml_display_type = "<publicObject id='druid:aa111aa1111'>#{@rights_metadata}#{@identity_metadata}#{@content_metadata}</publicObject>"
       display_type = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', Nokogiri::XML(public_xml_display_type)).parse_dor_display_type
@@ -212,11 +212,11 @@ describe DiscoveryIndexer::InputXml::PurlxmlParserStrict do
     end
   end
 
-  describe '.parse_collection_druids' do
+  describe '#parse_collection_druids' do
     pending
   end
 
-  describe '.parse_is_collection' do
+  describe '#parse_is_collection' do
     pending
   end
 

--- a/spec/discovery-indexer/reader/purlxml_spec.rb
+++ b/spec/discovery-indexer/reader/purlxml_spec.rb
@@ -29,7 +29,7 @@ describe DiscoveryIndexer::InputXml::Purlxml do
       VCR.use_cassette('available_purl_xml') do
         druid = 'tn629pk3948'
         p = DiscoveryIndexer::InputXml::Purlxml.new(druid)
-        model = p.load
+        p.load
 
         p.instance_variable_set(:@druid, 'aa111aa1111')
         model = p.load

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,6 @@
+require 'coveralls'
+Coveralls.wear!
+
 require 'webmock/rspec'
 require 'equivalent-xml'
 require 'discovery-indexer'


### PR DESCRIPTION
basically a bunch of housekeeping prior to making the changes needed for virtual objects being indexed into SearchWorks.

trying to keep things in manageable pieces for review.

The only thing I saw as slightly dangerous was making methods private -- but I checked the revs-indexer and sw-indexer-service code and they are not calling any of the methods I made private.  Spotlight doesn't use this code.

I also make the parsed chunks of public xml  memoized as it's silly to parse the content_metadata over and over, for example.  I couldn't see a risk to it ... can anyone else?

@lmcglohon @peetucket   might be good if you both weighed in on these changes.

connects with sul-dlss/sw-indexer-service#47
