### PR TITLE
preparations before adding isConstituentOf data

### DIFF
--- a/lib/discovery-indexer/collection.rb
+++ b/lib/discovery-indexer/collection.rb
@@ -1,10 +1,9 @@
 module DiscoveryIndexer
 
-  # It caches the collection information such as name and catkey
+  # Collection information such as name (title/label) and catkey
   class Collection
 
     attr_reader :druid
-    delegate :present?, to: :collection_info
 
     def initialize(druid)
       @druid = druid
@@ -20,17 +19,11 @@ module DiscoveryIndexer
 
     private
 
-    # Returns the collection name from cache, otherwise will fetch it from PURL.
-    #
-    # @return [Hash] the collection data or [] if there is no name and catkey or the object is not a collection
+    # @return [Hash] the collection data as { title: 'coll title', ckey: catkey'}
     def collection_info
-      from_purl || {}
-    end
-
-    # @return [String] return the collection label from purl if available, nil otherwise
-    def from_purl
-      return unless purl_model
-      { title: purl_model.label, ckey: purl_model.catkey }
+      return {} unless purl_model
+      @info = {}
+      @info = { title: purl_model.label, ckey: purl_model.catkey } if @info.empty?
     end
 
     def purl_model

--- a/lib/discovery-indexer/general_mapper.rb
+++ b/lib/discovery-indexer/general_mapper.rb
@@ -18,10 +18,7 @@ module DiscoveryIndexer
       solr_doc
     end
 
-    # For each collection druid, return a Hash of coll name (as :title) and ckey. If the druid doesn't
-    # have a collection title, it will be excluded from the hash
-    # @return [Hash] keys are coll druids, and values are a hash of title and ckey for the coll druid
-    # e.g. {'aa00bb0001'=>{:title=>'my coll',:ckey=>'652'},'nt028fd5773'=>{:title=>'Revs coll',:ckey=>'88'}}
+    # @return [DiscoveryIndexer::Collection] for each collection druid, or [] if no collection druids
     def collection_data
       @collection_data ||= collection_druids.map do |cdruid|
         DiscoveryIndexer::Collection.new(cdruid)

--- a/lib/discovery-indexer/general_mapper.rb
+++ b/lib/discovery-indexer/general_mapper.rb
@@ -18,10 +18,10 @@ module DiscoveryIndexer
       solr_doc
     end
 
-    # It converts collection_druids list to a hash with names. If the druid doesn't
-    # have a collection name, it will be excluded from the hash
-    # @return [Hash] a hash with key of coll druid, and value as a hash of name and ckey
-    # e.g. {'aa00bb0001'=>{:name=>'Test Coll Name',:ckey=>'000001'},'nt028fd5773'=>{:name=>'Revs Institute Archive',:ckey=>'000002'}}
+    # For each collection druid, return a Hash of coll name (as :title) and ckey. If the druid doesn't
+    # have a collection title, it will be excluded from the hash
+    # @return [Hash] keys are coll druids, and values are a hash of title and ckey for the coll druid
+    # e.g. {'aa00bb0001'=>{:title=>'my coll',:ckey=>'652'},'nt028fd5773'=>{:title=>'Revs coll',:ckey=>'88'}}
     def collection_data
       @collection_data ||= collection_druids.map do |cdruid|
         DiscoveryIndexer::Collection.new(cdruid)

--- a/lib/discovery-indexer/reader/purlxml.rb
+++ b/lib/discovery-indexer/reader/purlxml.rb
@@ -1,25 +1,27 @@
 module DiscoveryIndexer
   module InputXml
-    # This class is the main class to access and parse the purl xml
-    #    as retrieved from PURL server
+    # Main model class to access the parsed purl xml retrieved from PURL server
     # @example to run the code
-    #  druid = "aa111aa1111"
-    #  p =  DiscoveryIndexer::InputXml::Purlxml.new(druid)
-    #  model =  p.load()
+    #    druid = "aa111aa1111"
+    #    p =  DiscoveryIndexer::InputXml::Purlxml.new(druid)
+    #    model =  p.load()
+    #  then you can access the bits of interest
+    #    model.collection_druids
     class Purlxml
       # initializes a new object
       # @param druid [String] the druid object in the format "aa111aa1111"
       def initialize(druid)
         @druid = druid
         @purlxml_ng_doc = nil
+        @populated_model = nil
       end
 
       # loads the purl xml to purlxml model for the fedora object defind in the druid,
       # it reads the purl xml once from PURL server, and repeat the parsing with each call
       # @return [PurlxmlModel] represents the purlxml
       def load
-        @purlxml_ng_doc = PurlxmlReader.read(@druid) if @purlxml_ng_doc.nil?
-        PurlxmlParserStrict.new(@druid, @purlxml_ng_doc).parse
+        @purlxml_ng_doc ||= PurlxmlReader.read(@druid)
+        @populated_model ||= PurlxmlParserStrict.new(@druid, @purlxml_ng_doc).parse
       end
     end
   end

--- a/lib/discovery-indexer/reader/purlxml_parser_strict.rb
+++ b/lib/discovery-indexer/reader/purlxml_parser_strict.rb
@@ -129,6 +129,17 @@ module DiscoveryIndexer
         end
       end
 
+      # get the druids from predicate relationships in rels-ext from public_xml
+      # @return [Array<String>, nil] the druids (e.g. ww123yy1234) from the rdf:resource of the predicate relationships, or nil if none
+      def parse_predicate_druids(predicate, predicate_ns)
+        ns_hash = { 'rdf' => 'http://www.w3.org/1999/02/22-rdf-syntax-ns#', 'pred_ns' => predicate_ns }
+        xpth = "/publicObject/rdf:RDF/rdf:Description/pred_ns:#{predicate}/@rdf:resource"
+        pred_nodes = @purlxml_ng_doc.xpath(xpth, ns_hash)
+        pred_nodes.reject { |n| n.value.empty? }.map do |n|
+          n.value.split('druid:').last
+        end
+      end
+
       # the value of the type attribute for a DOR object's contentMetadata
       #  more info about these values is here:
       #    https://consul.stanford.edu/display/chimera/DOR+content+types%2C+resource+types+and+interpretive+metadata

--- a/lib/discovery-indexer/reader/purlxml_parser_strict.rb
+++ b/lib/discovery-indexer/reader/purlxml_parser_strict.rb
@@ -6,6 +6,7 @@ module DiscoveryIndexer
       RDF_NAMESPACE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#'
       OAI_DC_NAMESPACE = 'http://www.openarchives.org/OAI/2.0/oai_dc/'
       MODS_NAMESPACE = 'http://www.loc.gov/mods/v3'
+      FEDORA_NAMESPACE = 'info:fedora/fedora-system:def/relations-external#'
 
       def initialize(druid, purlxml_ng_doc)
         @purlxml_ng_doc = purlxml_ng_doc
@@ -21,10 +22,10 @@ module DiscoveryIndexer
         purlxml_model.content_metadata  = parse_content_metadata
         purlxml_model.identity_metadata = parse_identity_metadata
         purlxml_model.rights_metadata   = parse_rights_metadata
-        purlxml_model.dc                = parse_dc
+        purlxml_model.dc                = parse_dc # why do we care?
         purlxml_model.rdf               = parse_rdf
         purlxml_model.is_collection     = parse_is_collection
-        purlxml_model.collection_druids = parse_collection_druids
+        purlxml_model.collection_druids = parse_predicate_druids('isMemberOfCollection', FEDORA_NAMESPACE)
         purlxml_model.dor_content_type  = parse_dor_content_type
         purlxml_model.dor_display_type  = parse_dor_display_type
         purlxml_model.release_tags_hash = parse_release_tags_hash
@@ -116,17 +117,6 @@ module DiscoveryIndexer
           return true if object_type_nodes.find_index { |n| %w(collection set).include? n.text.downcase }
         end
         false
-      end
-
-      # get the druids from isMemberOfCollection relationships in rels-ext from public_xml
-      # @return [Array<String>] the druids (e.g. ww123yy1234) this object has isMemberOfColletion relationship with, or nil if none
-      def parse_collection_druids
-        ns_hash = { 'rdf' => 'http://www.w3.org/1999/02/22-rdf-syntax-ns#', 'fedora' => 'info:fedora/fedora-system:def/relations-external#', '' => '' }
-        is_member_of_nodes ||= @purlxml_ng_doc.xpath('/publicObject/rdf:RDF/rdf:Description/fedora:isMemberOfCollection/@rdf:resource', ns_hash)
-        # from public_xml rels-ext
-        is_member_of_nodes.reject { |n| n.value.empty? }.map do |n|
-          n.value.split('druid:').last
-        end
       end
 
       # get the druids from predicate relationships in rels-ext from public_xml

--- a/spec/discovery-indexer/collection_spec.rb
+++ b/spec/discovery-indexer/collection_spec.rb
@@ -3,23 +3,41 @@ require 'spec_helper'
 describe DiscoveryIndexer::Collection do
   let(:druid) { 'abc123' }
   let(:subject) { described_class.new(druid) }
-  let(:purl_model) { double('purl-model', label: 'Title', catkey: nil) }
-  let(:purl_model_ckey) { double('purl-model', label: 'Title', catkey: '12345') }
+  let(:purl_model_no_ckey) { double('purl-model', label: 'Title_no_ckey', catkey: nil) }
+  let(:purl_model_w_ckey) { double('purl-model', label: 'Title_ckey', catkey: '12345') }
 
-  describe '.searchworks_id' do
-    it 'should return druid if no catkey' do
-      allow(subject).to receive_messages(purl_model: purl_model)
+  describe '#searchworks_id' do
+    it 'druid if no catkey' do
+      allow(subject).to receive_messages(purl_model: purl_model_no_ckey)
       expect(subject.searchworks_id).to eq('abc123')
     end
-    it 'should return catkey if catkey exists' do
-      allow(subject).to receive_messages(purl_model: purl_model_ckey)
+    it 'catkey if catkey exists' do
+      allow(subject).to receive_messages(purl_model: purl_model_w_ckey)
       expect(subject.searchworks_id).to eq('12345')
     end
   end
-  describe '.title' do
-    it 'should return title' do
-      allow(subject).to receive_messages(purl_model: purl_model_ckey)
-      expect(subject.title).to eq('Title')
+
+  describe '#title' do
+    it 'purl_model.label' do
+      allow(subject).to receive_messages(purl_model: purl_model_w_ckey)
+      expect(subject.title).to eq('Title_ckey')
+      allow(subject).to receive_messages(purl_model: purl_model_no_ckey)
+      expect(subject.title).to eq('Title_no_ckey')
+    end
+  end
+
+  context '#collection_info' do
+    it '{title: nil, ckey: nnn} if no purl_model.label' do
+      allow(subject).to receive(:purl_model).and_return(double('purl-model', label: nil, catkey: '666'))
+      expect(subject.send(:collection_info)).to eq(title: nil, ckey: '666')
+    end
+    it '{title: ttt, catkey: nnn} if public_xml has ckey' do
+      allow(subject).to receive(:purl_model).and_return(purl_model_w_ckey)
+      expect(subject.send(:collection_info)).to eq(title: 'Title_ckey', ckey: '12345')
+    end
+    it '{title: ttt} if public_xml has no ckey' do
+      expect(subject).to receive_messages(purl_model: purl_model_no_ckey)
+      expect(subject.send(:collection_info)).to eq(title: 'Title_no_ckey', ckey: nil)
     end
   end
 end

--- a/spec/discovery-indexer/reader/purlxml_parser_strict_spec.rb
+++ b/spec/discovery-indexer/reader/purlxml_parser_strict_spec.rb
@@ -14,6 +14,13 @@ describe DiscoveryIndexer::InputXml::PurlxmlParserStrict do
   end
 
   describe '#parse' do
+    before(:each) do |*args|
+      allow(parser).to receive(:parse_content_metadata).and_return(@content_metadata)
+      allow(parser).to receive(:parse_identity_metadata)
+      allow(parser).to receive(:parse_rights_metadata)
+      allow(parser).to receive(:parse_dc)
+      allow(parser).to receive(:parse_rdf)
+    end
     it 'should call all methods and fill the require fields in the model' do
       parser = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('aa111aa1111', nil)
       allow(parser).to receive(:parse_content_metadata) { 'contentMetadata' }
@@ -36,7 +43,7 @@ describe DiscoveryIndexer::InputXml::PurlxmlParserStrict do
       allow(parser).to receive(:parse_sourceid) { 'sourceid' }
 
       model = parser.parse
-      expect(model.druid).to eq('aa111aa1111')
+      expect(model.druid).to eq(fake_druid)
       expect(model.public_xml).to be_nil
       expect(model.content_metadata).to eq('contentMetadata')
       expect(model.identity_metadata).to eq('identityMetadata')
@@ -44,6 +51,20 @@ describe DiscoveryIndexer::InputXml::PurlxmlParserStrict do
       expect(model.dc).to eq('dc')
       expect(model.rdf).to eq('rdf')
       expect(model.label).to eq('label')
+    end
+    it 'collection_druids' do
+      allow(parser).to receive(:parse_catkey)
+      allow(parser).to receive(:parse_barcode)
+      allow(parser).to receive(:parse_label)
+      allow(parser).to receive(:parse_copyright)
+      allow(parser).to receive(:parse_use_and_reproduction)
+      allow(parser).to receive(:parse_sourceid)
+
+      coll_druids = ['ab123cd4567']
+      expect(parser).to receive(:parse_collection_druids).and_return(coll_druids)
+#      expect(parser).to receive(:parse_predicate_druids).with('isMemberOfCollection', fedora_ns).and_return(coll_druids)
+      model = parser.parse
+      expect(model.collection_druids).to eq coll_druids
     end
   end
 

--- a/spec/discovery-indexer/reader/purlxml_parser_strict_spec.rb
+++ b/spec/discovery-indexer/reader/purlxml_parser_strict_spec.rb
@@ -4,7 +4,7 @@ describe DiscoveryIndexer::InputXml::PurlxmlParserStrict do
 
   let(:fake_druid) { 'oo000oo0000' }
   let(:fedora_ns) { 'info:fedora/fedora-system:def/relations-external#' }
-  let(:parser) { DiscoveryIndexer::InputXml::PurlxmlParserStrict.new(fake_druid, nil) }
+  let(:parser) { described_class.new(fake_druid, nil) }
 
   before :all do
     @available_purl_xml_ng_doc = Nokogiri::XML(open('spec/fixtures/available_purl_xml_item.xml'), nil, 'UTF-8')
@@ -25,7 +25,7 @@ describe DiscoveryIndexer::InputXml::PurlxmlParserStrict do
       allow(parser).to receive(:parse_dc)
       allow(parser).to receive(:parse_rdf)
     end
-    it 'should call all methods and fill the require fields in the model' do
+    it 'calls parse methods to popuplate the required fields in the model' do
       allow(parser).to receive(:parse_identity_metadata) { 'identityMetadata' }
       allow(parser).to receive(:parse_rights_metadata) { 'rightsMetadata' }
       allow(parser).to receive(:parse_dc) { 'dc' }
@@ -66,7 +66,7 @@ describe DiscoveryIndexer::InputXml::PurlxmlParserStrict do
       allow(parser).to receive(:parse_file_ids)
       allow(parser).to receive(:parse_image_ids)
 
-      coll_druids = ['ab123cd4567']
+      coll_druids = ['ab123cd4567', '666']
       expect(parser).to receive(:parse_predicate_druids).with('isMemberOfCollection', fedora_ns).and_return(coll_druids)
       model = parser.parse
       expect(model.collection_druids).to eq coll_druids
@@ -74,37 +74,37 @@ describe DiscoveryIndexer::InputXml::PurlxmlParserStrict do
   end
 
   describe '#parse_identity_metadata' do
-    it 'should returnt the identity metadata stream for the valid public xml' do
-      im = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', @available_purl_xml_ng_doc).send(:parse_identity_metadata)
+    it 'returns the identity metadata stream for the valid public xml' do
+      im = described_class.new('', @available_purl_xml_ng_doc).send(:parse_identity_metadata)
       expect(im).to be_kind_of(Nokogiri::XML::Document)
       expect(im.root.name).to eql('identityMetadata')
       expect(im.root.xpath('objectId').text).to eql('druid:tn629pk3948')
       expect(im).to be_equivalent_to(Nokogiri::XML(@identity_metadata))
     end
 
-    it "should raise an error when the public xml doesn't have identity metadata" do
+    it "raises an error when the public xml doesn't have identity metadata" do
       public_xml_no_identity = "<publicObject id='druid:aa111aa1111'>#{@content_metadata}#{@rights_metadata}</publicObject>"
-      expect { DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', public_xml_no_identity).send(:parse_identity_metadata) }.to raise_error(DiscoveryIndexer::Errors::MissingIdentityMetadata)
+      expect { described_class.new('', public_xml_no_identity).send(:parse_identity_metadata) }.to raise_error(DiscoveryIndexer::Errors::MissingIdentityMetadata)
     end
   end
 
   describe '#parse_rights_metadata' do
-    it 'should returnt the rights metadata stream for the valid public xml' do
-      im = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', @available_purl_xml_ng_doc).send(:parse_rights_metadata)
+    it 'returns the rights metadata stream for the valid public xml' do
+      im = described_class.new('', @available_purl_xml_ng_doc).send(:parse_rights_metadata)
       expect(im).to be_kind_of(Nokogiri::XML::Document)
       expect(im.root.name).to eql('rightsMetadata')
       expect(im).to be_equivalent_to(Nokogiri::XML(@rights_metadata))
     end
 
-    it "should raise an error when the public xml doesn't have rights metadata" do
+    it "raises an error when the public xml doesn't have rights metadata" do
       public_xml_no_rights = "<publicObject id='druid:aa111aa1111'>#{@content_metadata}#{@identity_metadata}</publicObject>"
-      expect { DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', public_xml_no_rights).send(:parse_rights_metadata) }.to raise_error(DiscoveryIndexer::Errors::MissingRightsMetadata)
+      expect { described_class.new('', public_xml_no_rights).send(:parse_rights_metadata) }.to raise_error(DiscoveryIndexer::Errors::MissingRightsMetadata)
     end
   end
 
   describe '#parse_dc' do
     it 'returns the Nokogiri XML Document from dc metadata in purl public xml' do
-      im = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', @available_purl_xml_ng_doc).send(:parse_dc)
+      im = described_class.new('', @available_purl_xml_ng_doc).send(:parse_dc)
       expect(im).to be_kind_of(Nokogiri::XML::Document)
       expect(im.root.name).to eql('dc')
       expect(im).to be_equivalent_to(Nokogiri::XML(@dc))
@@ -112,87 +112,87 @@ describe DiscoveryIndexer::InputXml::PurlxmlParserStrict do
 
     it 'raises an error for the metadata without dc' do
       public_xml_no_dc = "<publicObject id='druid:aa111aa1111'>#{@rights_metadata}#{@identity_metadata}#{@content_metadata}</publicObject>"
-      expect { DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', public_xml_no_dc).send(:parse_dc) }.to raise_error(DiscoveryIndexer::Errors::MissingDC)
+      expect { described_class.new('', public_xml_no_dc).send(:parse_dc) }.to raise_error(DiscoveryIndexer::Errors::MissingDC)
     end
   end
 
   describe '#parse_rdf' do
-    it 'should return the rdf for the valid public xml' do
-      im = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', @available_purl_xml_ng_doc).send(:parse_rdf)
+    it 'returns the rdf for the valid public xml' do
+      im = described_class.new('', @available_purl_xml_ng_doc).send(:parse_rdf)
       expect(im).to be_kind_of(Nokogiri::XML::Document)
       expect(im.root.name).to eql('RDF')
       expect(im).to be_equivalent_to(Nokogiri::XML(@rdf))
     end
 
-    it 'should raise an error for the metadata without dc' do
+    it 'raises an error for the metadata without dc' do
       public_xml_no_dc = "<publicObject id='druid:aa111aa1111'>#{@rights_metadata}#{@identity_metadata}#{@content_metadata}</publicObject>"
-      expect { DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', public_xml_no_dc).send(:parse_rdf) }.to raise_error(DiscoveryIndexer::Errors::MissingRDF)
+      expect { described_class.new('', public_xml_no_dc).send(:parse_rdf) }.to raise_error(DiscoveryIndexer::Errors::MissingRDF)
     end
   end
 
   describe '#parse_release_tags_hash' do
     it 'parses the release tags from ReleaseData in public XML' do
-      release_tags_hash = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', @available_purl_xml_ng_doc).send(:parse_release_tags_hash)
+      release_tags_hash = described_class.new('', @available_purl_xml_ng_doc).send(:parse_release_tags_hash)
       expect(release_tags_hash).to eq('revs_stage' => true, 'sw_prod' => false, 'sw_preview' => false)
     end
     it 'returns empty release tags from pulic XML in the absence of ReleaseData element' do
       reduced_purl_xml_ng = @available_purl_xml_ng_doc.clone
       reduced_purl_xml_ng.search('//ReleaseData').remove
-      release_tags_hash = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', reduced_purl_xml_ng).send(:parse_release_tags_hash)
+      release_tags_hash = described_class.new('', reduced_purl_xml_ng).send(:parse_release_tags_hash)
       expect(release_tags_hash).to eq({})
     end
     it 'returns empty release tags from nil pulic XML' do
-      release_tags_hash = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', nil).send(:parse_release_tags_hash)
+      release_tags_hash = described_class.new('', nil).send(:parse_release_tags_hash)
       expect(release_tags_hash).to eq({})
     end
   end
 
   describe '#parse_copyright' do
-    it 'should parse the copyright statement correctly' do
-      copyright = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', @available_purl_xml_ng_doc).send(:parse_copyright)
+    it 'parses the copyright statement correctly' do
+      copyright = described_class.new('', @available_purl_xml_ng_doc).send(:parse_copyright)
       expect(copyright).to eq('Test copyright statement. All rights reserved unless otherwise indicated.')
     end
   end
 
   describe '#parse_use_and_reproduction' do
-    it 'should parse the use and reproduction statement correctly' do
-      use_and_reproduction = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', @available_purl_xml_ng_doc).send(:parse_use_and_reproduction)
+    it 'parses the use and reproduction statement correctly' do
+      use_and_reproduction = described_class.new('', @available_purl_xml_ng_doc).send(:parse_use_and_reproduction)
       expect(use_and_reproduction).to eq('Digital recordings from this collection may be accessed freely. These files may not be reproduced or used for any purpose without permission. For permission requests, please contact Stanford University Department of Special Collections  University Archives (speccollref@stanford.edu).')
     end
   end
 
   describe '#parse_content_metadata' do
-    it 'should return the content metadata stream for the valid public xml' do
-      im = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', @available_purl_xml_ng_doc).send(:parse_content_metadata)
+    it 'returns the content metadata stream for the valid public xml' do
+      im = described_class.new('', @available_purl_xml_ng_doc).send(:parse_content_metadata)
       expect(im).to be_kind_of(Nokogiri::XML::Document)
       expect(im.root.name).to eql('contentMetadata')
       expect(im).to be_equivalent_to(Nokogiri::XML(@content_metadata))
     end
 
-    it "should return nil when the public xml doesn't have content metadata" do
+    it "returns nil when the public xml doesn't have content metadata" do
       public_xml_no_content = "<publicObject id='druid:aa111aa1111'>#{@rights_metadata}#{@identity_metadata}</publicObject>"
-      cm = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', Nokogiri::XML(public_xml_no_content)).send(:parse_content_metadata)
+      cm = described_class.new('', Nokogiri::XML(public_xml_no_content)).send(:parse_content_metadata)
       expect(cm).to be_nil
     end
   end
 
   describe 'Parse File and Image IDs' do
-    it 'should return nil when no content metadata is present' do
+    it 'returns nil when no content metadata is present' do
       public_xml_no_content = "<publicObject id='druid:aa111aa1111'>#{@rights_metadata}#{@identity_metadata}</publicObject>"
-      pm = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', Nokogiri::XML(public_xml_no_content))
+      pm = described_class.new('', Nokogiri::XML(public_xml_no_content))
       expect(pm.send(:parse_image_ids)).to be_nil
       expect(pm.send(:parse_file_ids)).to be_nil
     end
 
-    it 'should return nil when content metadata is present but no image or page ids are present' do
+    it 'returns nil when content metadata is present but no image or page ids are present' do
       public_xml_no_content = "<publicObject id='druid:aa111aa1111'>#{@rights_metadata}#{@identity_metadata}#{@blank_content_metadata}</publicObject>"
-      pm = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', Nokogiri::XML(public_xml_no_content))
+      pm = described_class.new('', Nokogiri::XML(public_xml_no_content))
       expect(pm.send(:parse_image_ids)).to be_empty
       expect(pm.send(:parse_file_ids)).to be_nil
     end
 
-    it 'should return image and page ids when present' do
-      pm = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', @available_purl_xml_ng_doc)
+    it 'returns image and page ids when present' do
+      pm = described_class.new('', @available_purl_xml_ng_doc)
       expect(pm.send(:parse_image_ids)).to eq(['tn629pk3948_img_1.jp2', 'tn629pk3948_img_2.jp2', 'tn629pk3948_img_3.jp2', 'tn629pk3948_pg_1.jp2'])
       expect(pm.send(:parse_file_ids)).to eq(["tn629pk3948_sl.mp4", "tn629pk3948_img_1.jp2", "tn629pk3948_img_2.jp2", "tn629pk3948_img_3.jp2", "tn629pk3948_pg_1.pdf", "tn629pk3948_pg_1.jp2", "tn629pk3948_pg_1.pdf"])
     end
@@ -211,29 +211,29 @@ describe DiscoveryIndexer::InputXml::PurlxmlParserStrict do
   end
 
   describe '#parse_dor_content_type' do
-    it 'should return valid dor content type for valid druid' do
-      content_type = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', @available_purl_xml_ng_doc).send(:parse_dor_content_type)
+    it 'returns valid dor content type for valid druid' do
+      content_type = described_class.new('', @available_purl_xml_ng_doc).send(:parse_dor_content_type)
       expect(content_type).to eq('media')
     end
 
-    it 'should return nil dor content type if there is no content metadata' do
+    it 'returns nil dor content type if there is no content metadata' do
       public_xml_no_content = "<publicObject id='druid:aa111aa1111'>#{@rights_metadata}#{@identity_metadata}</publicObject>"
-      content_type = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', Nokogiri::XML(public_xml_no_content)).send(:parse_dor_content_type)
+      content_type = described_class.new('', Nokogiri::XML(public_xml_no_content)).send(:parse_dor_content_type)
       expect(content_type).to be_nil
     end
   end
 
   describe '#parse_dor_display_type' do
-    it 'should return valid dor displayTypeype for valid druid' do
+    it 'returns valid dor displayTypeype for valid druid' do
       public_xml_display_type = "<publicObject id='druid:aa111aa1111'>#{@rights_metadata}#{@identity_metadata}#{@content_metadata}</publicObject>"
-      display_type = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', Nokogiri::XML(public_xml_display_type)).send(:parse_dor_display_type)
+      display_type = described_class.new('', Nokogiri::XML(public_xml_display_type)).send(:parse_dor_display_type)
       expect(display_type).to eq('image')
     end
 
-    it 'should return nil dor displayType if there is no displayType in the identity metadata' do
+    it 'returns nil dor displayType if there is no displayType in the identity metadata' do
       im_no_display_type = '  <identityMetadata>    <sourceId source="sul">V0401_b1_1.01</sourceId>    <objectId>druid:tn629pk3948</objectId>    <objectCreator>DOR</objectCreator>    <objectLabel>Lecture 1</objectLabel>    <objectType>item</objectType>    <adminPolicy>druid:ww057vk7675</adminPolicy>    <otherId name="label"/>    <otherId name="uuid">08d544da-d459-11e2-8afb-0050569b3c3c</otherId>    <tag>Project:V0401 mccarthyism:vhs</tag>    <tag> Process:Content Type:Media</tag>    <tag> JIRA:DIGREQ-592</tag>    <tag> SMPL:video:ua</tag>    <tag> Registered By:gwillard</tag>    <tag>Remediated By : 4.6.6.2</tag>  </identityMetadata>'
       public_xml_no_display_type = "<publicObject id='druid:aa111aa1111'>#{@rights_metadata}#{im_no_display_type}#{@content_metadata}</publicObject>"
-      display_type = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', Nokogiri::XML(public_xml_no_display_type)).send(:parse_dor_display_type)
+      display_type = described_class.new('', Nokogiri::XML(public_xml_no_display_type)).send(:parse_dor_display_type)
       expect(display_type).to be_empty
     end
   end
@@ -243,17 +243,18 @@ describe DiscoveryIndexer::InputXml::PurlxmlParserStrict do
       Nokogiri::XML <<-EOF
         <publicObject id='druid:#{fake_druid}'>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fedora="#{fedora_ns}">
-          <rdf:Description rdf:about="info:fedora/druid:#{fake_druid}">
-            <fedora:isMemberOf rdf:resource="info:fedora/druid:xh235dd9059"/>
-            <fedora:isMemberOfCollection rdf:resource="info:fedora/druid:xh235dd9059"/>
-            <fedora:isMemberOfCollection rdf:resource="info:fedora/druid:aa097bm8879"/>
-            <fedora:isConstituentOf rdf:resource="info:fedora/druid:hj097bm8879"/>
-            <fedora:isEmpty/>
-          </rdf:Description>
-        </rdf:RDF>
+            <rdf:Description rdf:about="info:fedora/druid:#{fake_druid}">
+              <fedora:isMemberOf rdf:resource="info:fedora/druid:xh235dd9059"/>
+              <fedora:isMemberOfCollection rdf:resource="info:fedora/druid:xh235dd9059"/>
+              <fedora:isMemberOfCollection rdf:resource="info:fedora/druid:aa097bm8879"/>
+              <fedora:isConstituentOf rdf:resource="info:fedora/druid:hj097bm8879"/>
+              <fedora:isEmpty/>
+            </rdf:Description>
+          </rdf:RDF>
+        </publicObject>
         EOF
     end
-    let(:parser) { DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('', public_xml_ng) }
+    let(:parser) { described_class.new('', public_xml_ng) }
     it 'gets all druids for the desired predicate and only that predicate' do
       expect(parser.send(:parse_predicate_druids, 'isMemberOfCollection', fedora_ns)).to eq ['xh235dd9059', 'aa097bm8879']
       expect(parser.send(:parse_predicate_druids, 'isConstituentOf', fedora_ns)).to eq ['hj097bm8879']

--- a/spec/discovery-indexer/reader/purlxml_parser_strict_spec.rb
+++ b/spec/discovery-indexer/reader/purlxml_parser_strict_spec.rb
@@ -14,7 +14,7 @@ describe DiscoveryIndexer::InputXml::PurlxmlParserStrict do
   end
 
   describe '#parse' do
-    before(:each) do |*args|
+    before(:each) do
       allow(parser).to receive(:parse_content_metadata).and_return(@content_metadata)
       allow(parser).to receive(:parse_identity_metadata)
       allow(parser).to receive(:parse_rights_metadata)
@@ -22,8 +22,6 @@ describe DiscoveryIndexer::InputXml::PurlxmlParserStrict do
       allow(parser).to receive(:parse_rdf)
     end
     it 'should call all methods and fill the require fields in the model' do
-      parser = DiscoveryIndexer::InputXml::PurlxmlParserStrict.new('aa111aa1111', nil)
-      allow(parser).to receive(:parse_content_metadata) { 'contentMetadata' }
       allow(parser).to receive(:parse_identity_metadata) { 'identityMetadata' }
       allow(parser).to receive(:parse_rights_metadata) { 'rightsMetadata' }
       allow(parser).to receive(:parse_dc) { 'dc' }
@@ -45,7 +43,7 @@ describe DiscoveryIndexer::InputXml::PurlxmlParserStrict do
       model = parser.parse
       expect(model.druid).to eq(fake_druid)
       expect(model.public_xml).to be_nil
-      expect(model.content_metadata).to eq('contentMetadata')
+      expect(model.content_metadata).to eq(@content_metadata)
       expect(model.identity_metadata).to eq('identityMetadata')
       expect(model.rights_metadata).to eq('rightsMetadata')
       expect(model.dc).to eq('dc')

--- a/spec/discovery-indexer/reader/purlxml_parser_strict_spec.rb
+++ b/spec/discovery-indexer/reader/purlxml_parser_strict_spec.rb
@@ -31,7 +31,7 @@ describe DiscoveryIndexer::InputXml::PurlxmlParserStrict do
       allow(parser).to receive(:parse_dc) { 'dc' }
       allow(parser).to receive(:parse_rdf) { 'rdf' }
       allow(parser).to receive(:parse_is_collection) { false }
-      allow(parser).to receive(:parse_collection_druids) { ['druid:ab123cd4567'] }
+      allow(parser).to receive(:parse_predicate_druids).with('isMemberOfCollection', fedora_ns) { ['ab123cd4567'] }
       allow(parser).to receive(:parse_dor_content_type) { 'image' }
       allow(parser).to receive(:parse_dor_display_type) { 'image' }
       allow(parser).to receive(:parse_release_tags_hash) { '' }
@@ -61,10 +61,13 @@ describe DiscoveryIndexer::InputXml::PurlxmlParserStrict do
       allow(parser).to receive(:parse_copyright)
       allow(parser).to receive(:parse_use_and_reproduction)
       allow(parser).to receive(:parse_sourceid)
+      allow(parser).to receive(:parse_is_collection)
+      allow(parser).to receive(:parse_dor_content_type)
+      allow(parser).to receive(:parse_file_ids)
+      allow(parser).to receive(:parse_image_ids)
 
       coll_druids = ['ab123cd4567']
-      expect(parser).to receive(:parse_collection_druids).and_return(coll_druids)
-#      expect(parser).to receive(:parse_predicate_druids).with('isMemberOfCollection', fedora_ns).and_return(coll_druids)
+      expect(parser).to receive(:parse_predicate_druids).with('isMemberOfCollection', fedora_ns).and_return(coll_druids)
       model = parser.parse
       expect(model.collection_druids).to eq coll_druids
     end
@@ -261,10 +264,6 @@ describe DiscoveryIndexer::InputXml::PurlxmlParserStrict do
     it 'ignores predicate matches that have no object' do
       expect(parser.send(:parse_predicate_druids, 'isEmpty', fedora_ns)).to eq []
     end
-  end
-
-  describe '#parse_collection_druids' do
-    pending
   end
 
   describe '#parse_is_collection' do

--- a/spec/discovery-indexer/reader/purlxml_spec.rb
+++ b/spec/discovery-indexer/reader/purlxml_spec.rb
@@ -34,6 +34,7 @@ describe DiscoveryIndexer::InputXml::Purlxml do
         p.instance_variable_set(:@druid, 'aa111aa1111')
         model = p.load
 
+        # if the model was reloaded, then the below wouldn't be true because the data would change to match the druid
         expect(model.content_metadata).to be_equivalent_to(@content_metadata)
         expect(model.identity_metadata).to be_equivalent_to(@identity_metadata)
         expect(model.rights_metadata).to be_equivalent_to(@rights_metadata)


### PR DESCRIPTION
This is ready.  Again, would appreciate :eyes: from both @lmcglohon  and  @peetucket 

still no change in functionality;  trying to keep PRs easy to review.
- Collection: improve specs, refactor to be simpler and memoized, update comments to match code
- PurlxmlStrictParser:  add specs for collection_druids, refactor in prep for isConstituentOf
- GeneralMapper:  add specs for collection methods, and update comments to match code
- Purlxml:  update comments

Added tests for collection_druids, updated comments to match what collection information is actually returned

connected to sul-dlss/sw-indexer-service#47
