### PR TITLE
require at least version 2.1 of stanford-mods to fix location bug

### DIFF
--- a/discovery-indexer.gemspec
+++ b/discovery-indexer.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.require_path = 'lib'
 
   gem.add_dependency 'nokogiri'
-  gem.add_dependency 'stanford-mods'
+  gem.add_dependency 'stanford-mods', '~>2.1'
   gem.add_dependency 'retries'
   gem.add_dependency 'rsolr'
   gem.add_dependency 'rest-client'

--- a/lib/discovery-indexer/version.rb
+++ b/lib/discovery-indexer/version.rb
@@ -1,3 +1,3 @@
 module DiscoveryIndexer
-  VERSION = '1.0.0'
+  VERSION = '1.0.1'
 end


### PR DESCRIPTION
can then cut new gem and require updated gem in spotlight-indexer-service to get bug fix there

@lmcglohon @ndushay 
